### PR TITLE
Devise replacing bypass option with bypass_sign_in method

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -28,7 +28,13 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     end
 
     warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
-    sign_in resource_name, resource, :bypass => true
+    # use newer bypass_sign_in method if it exists in Devise
+    # https://github.com/plataformatec/devise/commit/2044fffa25d781fcbaf090e7728b48b65c854ccb
+    if respond_to?(:bypass_sign_in)
+      bypass_sign_in(resource, :scope => resource_name)
+    else
+      sign_in(resource_name, resource, :bypass => true)
+    end
     set_flash_message :notice, :success
     resource.update_attribute(:second_factor_attempts_count, 0)
 


### PR DESCRIPTION
The `bypass` option is being deprecated in Devise versions > 4.2. Replaced with a `bypass_sign_in` method.

More info: https://github.com/plataformatec/devise/commit/2044fffa25d781fcbaf090e7728b48b65c854ccb